### PR TITLE
Fix minimum perl version and META_MERGE

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,10 +21,11 @@ WriteMakefile(
   VERSION_FROM     => "lib/Class/Slot.pm",
   ABSTRACT_FROM    => 'README.pod',
   LICENSE          => 'perl_5',
-  MIN_PERL_VERSION => '5.0082',
+  MIN_PERL_VERSION => '5.008002',
   PREREQ_PRINT     => 1,
 
   META_MERGE => {
+    'meta-spec' => { version => 2 },
     resources => {
       homepage => "https://github.com/sysread/slot",
 


### PR DESCRIPTION
If you are attempting to set the minimum perl version to 5.8.2, that would be represented as '5.008002'. '5.0082' is perl 5.8.200, which essentially would just require perl 5.10. See http://blogs.perl.org/users/grinnz/2018/04/a-guide-to-versions-in-perl.html

Also set meta-spec to 2 in META_MERGE so that the repository and bugtracker metadata is respected (the default 1.4 spec version will ignore the current values as invalid).